### PR TITLE
Update pg_histogram.gemspec

### DIFF
--- a/pg_histogram.gemspec
+++ b/pg_histogram.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "~> 4.0"
-  spec.add_dependency "pg", "~> 0.1"
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_dependency "activerecord", ">= 4.0"
+  spec.add_dependency "pg", ">= 0.1"
+  spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
Hey! For my rails5 project pg_histogram couldn't be installed so I've updated a gemspec file. I'm not sure why you've made that dependencies. For me `histogram = PgHistogram::Histogram.new(Balance.all, 'value', 100).results` is working ok, so seems like gem is not broken with the current changes, but works on R5 ;)
